### PR TITLE
Rename CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  CI:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
From `test` to `CI`.  So that it reflects file name and purpose.
