### PR TITLE
Fix bad config in codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @guardian/devx-security
-* @guardian/devx-reliability-and-ops
+* @guardian/devx-security @guardian/devx-reliability-and-ops


### PR DESCRIPTION
The second line was overriding the first and giving a single code owner rather than both teams.
