### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
     groups:
       # The AWS SDK dependencies must be updated in unison.
       # See https://github.com/aws/aws-sdk-go-v2/issues/2370#issuecomment-1878423518.


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

